### PR TITLE
Handle case sensitive file systems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 sudo: false
 language: node_js
+os:
+  - linux
+  - osx
 node_js:
-  - "stable"
+  - "6"
   - "5"
   - "4"
   - "0.12"

--- a/index.js
+++ b/index.js
@@ -30,6 +30,10 @@ var path = require('path');
  */
 
 module.exports = function(filepath) {
+  if (!filepath || (typeof filepath !== 'string')) {
+    return false;
+  }
+
   try {
     (fs.accessSync || fs.statSync)(filepath);
     return filepath;

--- a/index.js
+++ b/index.js
@@ -8,11 +8,96 @@
 'use strict';
 
 var fs = require('fs');
+var path = require('path');
+
+/**
+ * Check if the given `filepath` exists.
+ *
+ * ```js
+ * var res = exists('package.json');
+ * console.log(res);
+ * //=> "package.json"
+ *
+ * var res = exists('fake-file.json');
+ * console.log(res)
+ * //=> false
+ * ```
+ *
+ * @name exists
+ * @param  {String} `filepath` filepath to check for.
+ * @return {String|Boolean} Returns the found filepath if it exists, otherwise returns `false`.
+ * @api public
+ */
 
 module.exports = function(filepath) {
   try {
     (fs.accessSync || fs.statSync)(filepath);
-    return true;
+    return filepath;
   } catch (err) {}
+
+  if (process.platform === 'linux') {
+    return exists(filepath);
+  }
   return false;
 };
+
+/**
+ * Check if the filepath exists by falling back to reading in the entire directory.
+ * Returns the real filepath (for case sensitive file systems) if found.
+ *
+ * @param  {String} `filepath` filepath to check.
+ * @return {String|Boolean} Returns found filepath if exists, otherwise false.
+ */
+
+function exists(filepath) {
+  filepath = path.resolve(filepath);
+  var res = tryReaddir(filepath);
+  if (res === null) {
+    return false;
+  }
+
+  // "filepath" is a directory, an error would be
+  // thrown if it doesn't exist. if we're here, it exists
+  if (res.path === filepath) {
+    return res.path;
+  }
+
+  // "fp" is not a directory
+  var lower = filepath.toLowerCase();
+  var len = res.files.length;
+  var idx = -1;
+
+  while (++idx < len) {
+    var fp = path.resolve(res.path, res.files[idx]);
+    if (filepath === fp || lower === fp) {
+      return fp;
+    }
+    var fpLower = fp.toLowerCase();
+    if (filepath === fpLower || lower === fpLower) {
+      return fp;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Try to read the filepath as a directory first, then fallback to the filepath's dirname.
+ *
+ * @param  {String} `filepath` path of the directory to read.
+ * @return {Object} Object containing `path` and `files` if succesful. Otherwise, null.
+ */
+
+function tryReaddir(filepath) {
+  var ctx = { path: filepath, files: [] };
+  try {
+    ctx.files = fs.readdirSync(filepath);
+    return ctx;
+  } catch (err) {}
+  try {
+    ctx.path = path.dirname(filepath);
+    ctx.files = fs.readdirSync(ctx.path);
+    return ctx;
+  } catch (err) {}
+  return null;
+}

--- a/test.js
+++ b/test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 require('mocha');
+var path = require('path');
 var assert = require('assert');
 var exists = require('./');
 var isLinux = process.platform === 'linux';
@@ -26,8 +27,8 @@ describe('fs-exists-sync', function() {
   });
 
   it('should handle case sensitive names on linux', function() {
-    assert.equal(exists('readme.md'), (isLinux ? 'README.md' : 'readme.md'));
-    assert.equal(exists('license'), (isLinux ? 'LICENSE' : 'license'));
+    assert.equal(exists('readme.md'), (isLinux ? path.resolve('README.md') : 'readme.md'));
+    assert.equal(exists('license'), (isLinux ? path.resolve('LICENSE') : 'license'));
   });
 
   it('should return true when a file exists', function() {

--- a/test.js
+++ b/test.js
@@ -3,13 +3,14 @@
 require('mocha');
 var assert = require('assert');
 var exists = require('./');
+var isLinux = process.platform === 'linux';
 
 describe('fs-exists-sync', function() {
   it('should export a function', function() {
     assert.equal(typeof exists, 'function');
   });
 
-  it('should return true when a file exists', function() {
+  it('should be truthy a file exists', function() {
     assert(exists('README.md'));
     assert(exists('LICENSE'));
   });
@@ -17,6 +18,16 @@ describe('fs-exists-sync', function() {
   it('should not be case sensitive', function() {
     assert(exists('readme.md'));
     assert(exists('license'));
+  });
+
+  it('should return filepath when a file exists', function() {
+    assert.equal(exists('README.md'), 'README.md');
+    assert.equal(exists('LICENSE'), 'LICENSE');
+  });
+
+  it('should handle case sensitive names on linux', function() {
+    assert.equal(exists('readme.md'), (isLinux ? 'README.md' : 'readme.md'));
+    assert.equal(exists('license'), (isLinux ? 'LICENSE' : 'license'));
   });
 
   it('should return true when a file exists', function() {


### PR DESCRIPTION
This is the code that @jonschlinkert and I worked through to provide a fallback for platforms like `linux` that are case sensitive.
- First try `fs.accessSync` or `fs.statSync`.
  - If exact match, these methods will succeed.
  - If case insensitive file system and file exists, these methods will succeed.
  - If case sensitive file system and file exists but different case, these methods will fail.
  - Returns given `filepath` on success (change from previous version which returned true).
- On case sensitive file systems (`linux`) fall back to checking entire directory for file.
  - Try to read `filepath` as a directory
  - Try to read `dirname(filepath)` as a directory
  - If `filepath` is a directory and read successful, return `filepath`
  - Iterate over files in directory and compare resolved filepaths to given filepath.
    - strict compare (same case)
    - lower cased filepath with directory filepath
    - given filepath with lowercased directory filepath
    - lower cased filepath with lowercased directory filepath
  - If any comparison matches, return matched filepath that was read in from the directory. This give consuming libraries a way to use the actual filepath with `fs` methods without having to redo all this searching and checks again.
